### PR TITLE
Sumcheck Prover Implementation

### DIFF
--- a/sumcheck/src/mle.rs
+++ b/sumcheck/src/mle.rs
@@ -21,6 +21,11 @@ use shared_types::Field;
 /// As a second hint, we give as fact the following relationship (please
 /// justify on your own!):
 /// f(r_1, b_2, ..., b_n) = (1 - r_1) * f(0, b_2, ..., b_n) + r_1 * f(1, b_2, ..., b_n)
+/// 
+/// RHS is clearly multilinear since f(0, b_2, ..., b_n) and f(1, b_2, ..., b_n) are
+/// multilinear. RHS can be thought of as a multilinear polynomial f'(r_1,x). Now to 
+/// prove f'==f we know that f and f' agree on {0,1}^n, thus f and f' must be equivalent
+
 #[derive(Clone)]
 pub struct MultilinearExtension<F> {
     bookkeping_table: Vec<F>,
@@ -56,5 +61,24 @@ impl<F: Field> MultilinearExtension<F> {
             // `idx`-th position is stored explicitly in `self.f`
             Some(self.bookkeping_table[idx])
         }
+    }
+
+         /// Return the table
+    pub fn table(&self) -> &[F] {
+        &self.bookkeping_table
+    }
+
+
+    /// Restrict the first variable and update table in place
+    pub fn restrict_first_var(table: &mut Vec<F>, r: F) {
+        if table.len() == 1 { return; }
+        let half = table.len() / 2;
+        for i in 0..half {
+            // Use fact f(r_1, b_2, ..., b_n) = (1 - r_1) * f(0, b_2, ..., b_n) + r_1 * f(1, b_2, ..., b_n)
+            let l = table[i];
+            let h = table[i + half];
+            table[i] = (F::ONE - r) * l + r * h;
+        }
+        table.truncate(half);
     }
 }

--- a/sumcheck/src/sumcheck.rs
+++ b/sumcheck/src/sumcheck.rs
@@ -1,4 +1,4 @@
-use crate::{mle::MultilinearExtension, utils::SumcheckProof};
+use crate::{mle::MultilinearExtension, utils::{SumcheckProof, UnivariateEvals}};
 use shared_types::{transcript::TranscriptSponge, Field};
 
 /// TODO: Fill out the `sumcheck_prove` function!
@@ -34,12 +34,161 @@ use shared_types::{transcript::TranscriptSponge, Field};
 /// * The form of the univariate polynomials which the prover must send is given
 /// by the struct [UnivariateEvals]. Make sure that you are following this
 /// convention!
+
+
+/// Helper for \sum_{b \in {0,1}^n} \prod f_k(b) -- runs in O(|mles|*2^n) time
+fn sum_over_hypercube<F: Field>(
+    mles: &[MultilinearExtension<F>],
+    n: usize,
+) -> F {
+    let total_points = 1usize << n;      //2^n points
+    let mut final_sum = F::ZERO;
+
+    // Enumerate each b \in {0,1}^n an integer idx. 
+    for idx in 0..total_points {
+       
+        let mut prod = F::ONE;
+
+        for f in mles {
+            // number of variables in the current MLE
+            let n_k = f.num_vars();       
+
+            // drop the low (n - n_k) bits since they are not in this MLE
+            let curr_mle_idx = idx >> (n - n_k);      
+            
+            prod *= f
+                .get(curr_mle_idx)
+                .unwrap();
+        }
+        final_sum += prod;
+    }
+    final_sum
+}
+
+
+
+/// Evaluate univariate polynomial \sum_{b}\prod f_k(r_1,r_2,X_i,b_i+1,...) and return the vector of evaluations.
+fn eval_round_univariate<F: Field>(
+    const_prod: F,  // product of inactive factors
+    active_factors: &[(&Vec<F>, usize)],  // (table, vars_left) pairs still containing x_i
+    num_remaining_vars: usize,
+) -> Vec<F> {
+
+    // Number of remaining points (b_i+1, ... b_n) =  2^{num_remaining_vars}
+    let num_remaining_pts  = 1usize << num_remaining_vars;
+
+    // Number of non-constant factors -- also the degree of X_i
+    let d_i   = active_factors.len(); 
+
+    let mut evals = Vec::with_capacity(d_i + 1);
+
+    // Evaluate for alpha in [d_i] -- O(d_i^2 2^{n-i-1}) time
+    for alpha in 0..=d_i {
+
+        let a = F::from(alpha as u64);
+        let mut sum = F::ZERO;
+
+        for point in 0..num_remaining_pts {
+
+            let mut prod = const_prod;
+
+            // multiply by each active_factor evaluated at (x_i = a, point).
+            for (tab, v_left) in active_factors {
+
+                // vars after x_i in this MLE
+                let num_remaining_vars_in_mle = v_left - 1; 
+
+                // drop these bits
+                let shift      = num_remaining_vars - num_remaining_vars_in_mle;   
+
+                // index into MLE table
+                let base_idx   = point >> shift;  
+
+                // 2^{num_remaining_vars_in_mle‑1}
+                let half_sz    = 1usize << num_remaining_vars_in_mle;
+
+                // Use fact f(a, b_2, ..., b_n) = (1 - a) * f(0, b_2, ..., b_n) + a * f(1, b_2, ..., b_n)
+                let low  = tab[base_idx];
+                let high = tab[base_idx + half_sz];
+                prod *= (F::ONE - a) * low + a * high;
+            }
+            sum += prod;
+        }
+        evals.push(sum);
+    }
+    evals
+}
+
+/// In‑place update of every active table after receiving verifier challenge r_i.
+fn restrict_all_active_tables<F: Field>(tables: &mut [Vec<F>], vars_left: &mut [usize], r_i: F) {
+    for (tab, v_left) in tables.iter_mut().zip(vars_left) {
+        if *v_left > 0 {
+            MultilinearExtension::restrict_first_var(tab, r_i);
+            *v_left -= 1;
+        }
+    }
+}
+
+
+
 fn sumcheck_prove<F: Field>(
     transcript: &mut impl TranscriptSponge<F>,
     mles: &[MultilinearExtension<F>],
 ) -> SumcheckProof<F> {
-    /// Your code goes here!
-    todo!()
+
+    // Maximum number of variables across all MLE factors 
+    let n = mles.iter().map(|f| f.num_vars()).max().unwrap_or(0);
+
+    // Clone bookkeeping tables
+    let mut tables: Vec<Vec<F>> = mles.iter().map(|f| f.table().to_vec()).collect();
+
+    // Vector to store number of variables left in each MLE - initialized to f.num_vars()
+    let mut vars_left: Vec<usize> = mles.iter().map(|f| f.num_vars()).collect();
+
+    // Compute the Claimed Sum
+    let claimed = sum_over_hypercube::<F>(mles, n); 
+    transcript.absorb(claimed);
+
+    let mut prover_msgs = Vec::with_capacity(n);
+
+
+    // Tracks the constant MLEs once all their variables have been initialized
+    let mut const_prod = F::ONE;  
+    
+    for i in 0..n {
+
+        // Number of remaining variable x_j for j > i
+        let num_remaining_vars = n - i - 1;                 
+
+        // Collect all active factors (those with vars_left > 0)
+        let active_factors: Vec<(&Vec<F>, usize)> = tables
+            .iter()
+            .zip(&vars_left)
+            .filter(|(_, &v)| v > 0)
+            .map(|(t, &v)| (t, v))
+            .collect();
+
+        // Compute evaluations of g_i.
+        let evals = eval_round_univariate::<F>(const_prod, &active_factors, num_remaining_vars);
+        transcript.absorb_elements(&evals);
+        prover_msgs.push(UnivariateEvals::new(evals.clone()));
+
+        // Get verifier challenge r_i and update tables.
+        let r_i = transcript.squeeze();
+
+        // Update every active table
+        restrict_all_active_tables::<F>(&mut tables, &mut vars_left, r_i);
+
+
+        // Update the constant factors from "inactive" tables
+        for (tab, &v) in tables.iter().zip(&vars_left) {
+            if v == 0 {                   
+                const_prod *= tab[0];
+            }
+        }
+    }
+
+    SumcheckProof::new(claimed, prover_msgs)
 }
 
 fn sumcheck_verify<F: Field>(
@@ -153,6 +302,34 @@ mod tests {
         let final_eval_bytes = [
             181, 127, 104, 99, 220, 104, 30, 186, 9, 88, 85, 75, 164, 140, 2, 133, 151, 203, 2,
             158, 58, 173, 19, 46, 90, 224, 207, 221, 208, 143, 249, 14,
+        ];
+        let oracle_query = Fr::from_bytes_le(&final_eval_bytes);
+        assert!(sumcheck_verify(
+            &mut verifier_transcript,
+            proof,
+            oracle_query
+        ))
+    }
+
+    /// This test runs the sumcheck verifier on a sumcheck proof of the claimed
+    /// sum over a single multilinear extension.
+    ///
+    /// The oracle query in the verifier is intentionally incorrect to test whether
+    /// the implementation is sound (correctly identifies false proofs).
+    #[test]
+    #[should_panic]
+    fn test_implementation_soundness() {
+        const NUM_VARS_MLE_1: usize = 3;
+        let mut rng = test_rng();
+        let mle_1 = generate_random_mle_with_num_vars(&mut rng, NUM_VARS_MLE_1);
+        let mut prover_transcript = PoseidonSponge::default();
+    
+        let proof = sumcheck_prove(&mut prover_transcript, &[mle_1.clone()]);
+        let mut verifier_transcript = PoseidonSponge::default();
+    
+        let final_eval_bytes = [
+            127, 127, 104, 99, 220, 104, 30, 186, 9, 88, 85, 75, 164, 140, 2, 133, 151, 203, 2,
+            158, 58, 173, 19, 46, 90, 224, 207, 221, 208, 104, 249, 14,
         ];
         let oracle_query = Fr::from_bytes_le(&final_eval_bytes);
         assert!(sumcheck_verify(


### PR DESCRIPTION
Added functions to `mle.rs` and `sumcheck.rs`  

Sumcheck Prover for a product of MLEs. 

Summary:

1. Sumcheck Prover first calls sum_over_hypercube to compute the claimed sum
2. For each variable it then computes a univariate polynomial 
3. The function also keeps track of the constant values, i.e. MLEs that include only previously collapsed variables.
4. The function collapses variables in all MLEs at the end of the loop using a helper defined in `mle.rs`